### PR TITLE
Fix [#140] 카테고리 삭제 API null 핸들링 코드 추가

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/category/api/CategoryApiController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/api/CategoryApiController.java
@@ -52,6 +52,7 @@ public class CategoryApiController implements CategoryApi {
 
     @DeleteMapping("/categories/{categoryId}")
     public ResponseEntity<BaseResponse<?>> delete(@PathVariable("categoryId") Long categoryId) {
+        categoryService.isExist(categoryId);
         categoryTaskFacade.deleteCategoryTaskAndTasks(categoryId);
         categoryMsetFacade.deleteCategoryMsetAndMsets(categoryId);
         categoryTaskFacade.delete(categoryId);

--- a/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryMsetFacade.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryMsetFacade.java
@@ -36,7 +36,9 @@ public class CategoryMsetFacade {
 
     public void deleteCategoryMsetAndMsets(Long categoryId) {
         List<Long> msetIdList = categoryMsetService.deleteAndGetMsetIdList(categoryId);
-        deleteMsetById(msetIdList);
+        if (msetIdList != null) { // 카테고리에 등록된 모립세트가 있을 경우에만 delete
+            deleteMsetById(msetIdList);
+        }
     }
 
     public void deleteMsetById(List<Long> msetIdList) {

--- a/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryTaskFacade.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/facade/CategoryTaskFacade.java
@@ -75,7 +75,9 @@ public class CategoryTaskFacade {
     public void deleteCategoryTaskAndTasks(Long categoryId) {
         // CategoryTask -> Task 순으로 삭제
         List<Long> taskIdList = categoryTaskService.deleteAndGetTaskIdList(categoryId);
-        taskService.delete(taskIdList);
+        if (taskIdList != null) { // 카테고리에 등록된 태스크가 있는 경우에만 delete
+            taskService.delete(taskIdList);
+        }
     }
 
 

--- a/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryService.java
@@ -115,5 +115,11 @@ public class CategoryService {
         categoryRepository.deleteById(categoryId);
     }
 
+    public Category isExist(Long categoryId) {
+        return categoryRepository.findById(categoryId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+        );
+    }
+
 }
 

--- a/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryTaskService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/category/service/CategoryTaskService.java
@@ -19,8 +19,8 @@ public class CategoryTaskService {
 
     public List<Long> deleteAndGetTaskIdList(Long categoryId) {
         List<CategoryTask> categoryTaskList = categoryTaskRepository.findByCategoryId(categoryId);
-        if (categoryTaskList.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        if (categoryTaskList.isEmpty()) { // 카테고리에 등록된 태스크가 없는 경우
+            return null;
         }
         List<Long> taskIdList = categoryTaskList.stream()
                 .map(CategoryTask::getTaskId).

--- a/jaksim/src/main/java/org/sopt/jaksim/mset/service/CategoryMsetService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/mset/service/CategoryMsetService.java
@@ -25,8 +25,8 @@ public class CategoryMsetService {
     public List<Long> deleteAndGetMsetIdList(Long categoryId) {
         List<CategoryMset> categoryMsetList = getByCategoryId(categoryId);
         List<Long> msetIdList = categoryMsetList.stream().map(CategoryMset::getMsetId).collect(Collectors.toList());
-        if (categoryMsetList.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        if (categoryMsetList.isEmpty()) { // 카테고리에 등록된 모립세트가 없는 경우
+            return null;
         }
         categoryMsetRepository.deleteAll(categoryMsetList);
         return msetIdList;

--- a/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/task/service/TaskService.java
@@ -72,6 +72,9 @@ public class TaskService {
     }
 
     public void delete(List<Long> taskIdList) {
+        if (taskIdList == null) {
+            return;
+        }
         List<Task> taskList = taskRepository.findAllById(taskIdList);
         if (taskList.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);


### PR DESCRIPTION
## 📍 Issue
- closes #140 

## ✨ Key Changes
카테고리 삭제 API에서, 카테고리에 등록된 태스크, 모립세트가 없을 때 삭제하려 하니까 404 Not Found 이슈가 있었습니다.
태스크, 모립세트 모두 jpa 쿼리에서 조회되지 않은 경우 If문으로 null 핸들링 했습니다.

## 💬 To Reviewers



