### PR TITLE
Fix [#144] 카테고리 생성 시 mset이 없어도 생성될 수 있게 null 핸들링

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/mset/service/MsetService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/mset/service/MsetService.java
@@ -23,9 +23,11 @@ public class MsetService {
 
     public void createByCategory(CategoryCreateRequest categoryCreateRequest, Long categoryId) {
         List<Mset> msetList = categoryCreateRequest.msets();
-        for (Mset mset : msetList) {
-            mset = msetRepository.save(Mset.create(mset.getName(), mset.getUrl()));
-            categoryMsetRepository.save(CategoryMset.create(categoryId, mset.getId()));
+        if (msetList != null) {
+            for (Mset mset : msetList) {
+                mset = msetRepository.save(Mset.create(mset.getName(), mset.getUrl()));
+                categoryMsetRepository.save(CategoryMset.create(categoryId, mset.getId()));
+            }
         }
     }
 


### PR DESCRIPTION
## 📍 Issue
- closes #144 

## ✨ Key Changes
카테고리 생성 시 mset을 생성하는 로직에서 null인 경우를 핸들링했습니다.

## 💬 To Reviewers



